### PR TITLE
Make sensors configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.0 - 2024-01-16
+
+- Allow selection of data sources via command-line arguments and Nix module
+
 ## 1.5.0 - 2024-12-23
 
 - Add support for eBPF

--- a/module.nix
+++ b/module.nix
@@ -59,6 +59,16 @@ in
         example = "path/to/password.txt";
         description = mdDoc "File containing password for Bitcoin's RPC API.";
       };
+
+      sources = {
+        rpcGetconnectioncount = mkEnableOption "collecting getconnectioncount data (RPC)" // { default = true; };
+        rpcGetpeerinfo = mkEnableOption "collecting getpeerinfo data (RPC)" // { default = true; };
+        rpcGettxoutsetinfo = mkEnableOption "collecting gettxoutsetinfo data (RPC)" // { default = true; };
+        rpcGetnodeaddresses = mkEnableOption "collecting getnodeaddresses data (RPC)" // { default = true; };
+        rpcGetrawaddrman = mkEnableOption "collecting getrawaddrman data (RPC)" // { default = true; };
+        tracepointsNet = mkEnableOption "collecting net group data (tracepoints)" // { default = true; };
+        systemdIPAccounting = mkEnableOption "collecting IP accounting statistics (systemd)" // { default = true; };
+      };
     };
   };
 
@@ -98,6 +108,13 @@ in
           --rpc-user=${cfg.bitcoinRpcUser} \
           ${optionalString (cfg.bitcoinRpcPass != null) "--rpc-password=${cfg.bitcoinRpcPass}" } \
           ${optionalString (cfg.bitcoinRpcPassFile != null) "--rpc-password-file=${cfg.bitcoinRpcPassFile}" } \
+          ${if cfg.sources.rpcGetconnectioncount then "--record-rpc-getconnectioncount" else "--no-record-rpc-getconnectioncount"} \
+          ${if cfg.sources.rpcGetpeerinfo then "--record-rpc-getpeerinfo" else "--no-record-rpc-getpeerinfo"} \
+          ${if cfg.sources.rpcGettxoutsetinfo then "--record-rpc-gettxoutsetinfo" else "--no-record-rpc-gettxoutsetinfo"} \
+          ${if cfg.sources.rpcGetnodeaddresses then "--record-rpc-getnodeaddresses" else "--no-record-rpc-getnodeaddresses"} \
+          ${if cfg.sources.rpcGetrawaddrman then "--record-rpc-getrawaddrman" else "--no-record-rpc-getrawaddrman"} \
+          ${if cfg.sources.tracepointsNet then "--record-tracepoints-net" else "--no-record-tracepoints-net"} \
+          ${if cfg.sources.systemdIPAccounting then "--record-systemd-ip-accounting" else "--no-record-systemd-ip-accounting"} \
         '';
         Restart = "on-failure";
         RestartSec = "60s";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitcoin-monitor"
-version = "1.5.0"
+version = "1.6.0"
 description = "Monitoring infrastructure for Bitcoin Core"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/bitcoin_monitor/config.py
+++ b/src/bitcoin_monitor/config.py
@@ -55,6 +55,32 @@ class RPCConfig:
 
 
 @dataclass
+class SourcesConfig:
+    """Configuration settings for data sources."""
+
+    rpc_getconnectioncount: bool
+    rpc_getpeerinfo: bool
+    rpc_gettxoutsetinfo: bool
+    rpc_getnodeaddresses: bool
+    rpc_getrawaddrman: bool
+    systemd_ipaccounting: bool
+    tracepoints_net: bool
+
+    @classmethod
+    def parse(cls, args):
+        """Create class instance from command-line arguments."""
+        return cls(
+            rpc_getconnectioncount=args.record_rpc_getconnectioncount,
+            rpc_getpeerinfo=args.record_rpc_getpeerinfo,
+            rpc_gettxoutsetinfo=args.record_rpc_gettxoutsetinfo,
+            rpc_getnodeaddresses=args.record_rpc_getnodeaddresses,
+            rpc_getrawaddrman=args.record_rpc_getrawaddrman,
+            systemd_ipaccounting=args.record_systemd_ip_accounting,
+            tracepoints_net=args.record_tracepoints_net,
+        )
+
+
+@dataclass
 class Config:
     """Configuration settings."""
 
@@ -62,6 +88,7 @@ class Config:
     log_level: str
     results_path: Path
     rpc_conf: RPCConfig
+    sources: SourcesConfig
 
     @classmethod
     def parse(cls, args):
@@ -75,6 +102,7 @@ class Config:
             log_level=args.log_level.upper(),
             results_path=Path(args.result_path),
             rpc_conf=RPCConfig.parse(args),
+            sources=SourcesConfig.parse(args),
         )
 
     def to_dict(self):
@@ -133,6 +161,55 @@ def parse_args():
         type=Path,
         default=None,
         help="File containing Bitcoin Core RPC password",
+    )
+
+    parser.add_argument(
+        "--record-rpc-getconnectioncount",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Measure number of connections (getconnectioncount via RPC)",
+    )
+
+    parser.add_argument(
+        "--record-rpc-getpeerinfo",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record peer data (getpeerinfo via RPC)",
+    )
+
+    parser.add_argument(
+        "--record-rpc-gettxoutsetinfo",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record UTXO set data (gettxoutsetinfo via RPC)",
+    )
+
+    parser.add_argument(
+        "--record-rpc-getnodeaddresses",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record known peers addresses (getnodeaddresses via RPC)",
+    )
+
+    parser.add_argument(
+        "--record-rpc-getrawaddrman",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record raw addrman data (getrawaddrman via RPC)",
+    )
+
+    parser.add_argument(
+        "--record-systemd-ip-accounting",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record IP accounting statistics (via systemd)",
+    )
+
+    parser.add_argument(
+        "--record-tracepoints-net",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Record P2P network traffic (via tracepoints)",
     )
 
     args = parser.parse_args()

--- a/src/bitcoin_monitor/master.py
+++ b/src/bitcoin_monitor/master.py
@@ -47,6 +47,7 @@ class Master:
         if self.conf.sources.systemd_ipaccounting:
             sources.append(systemd.IPAccounting(*args))
 
+        log.info("Active sources: %s", [src.__class__.__name__ for src in sources])
         return sources
 
     async def run(self):

--- a/src/bitcoin_monitor/master.py
+++ b/src/bitcoin_monitor/master.py
@@ -20,33 +20,44 @@ class Master:
         """Custom logger."""
         return log.getLogger(self.__class__.__name__)
 
+    async def prepare_sources(self) -> list:
+        """Prepare data sources per configuration set via command-line arguments."""
+        sources = []
+
+        # RPC sources
+        args = (self.conf.rpc_conf, self.conf.results_path)
+        if self.conf.sources.rpc_getconnectioncount:
+            sources.append(rpc.GetConnectionCount(*args))
+        if self.conf.sources.rpc_getpeerinfo:
+            sources.append(rpc.GetPeerInfo(*args))
+        if self.conf.sources.rpc_gettxoutsetinfo:
+            sources.append(rpc.GetTxoutSetInfo(*args))
+        if self.conf.sources.rpc_getnodeaddresses:
+            sources.append(rpc.GetNodeAddresses(*args))
+        if self.conf.sources.rpc_getrawaddrman:
+            sources.append(rpc.GetRawAddrman(*args))
+
+        # tracepoint sources
+        args = (self.conf.results_path,)
+        if self.conf.sources.tracepoints_net:
+            sources.append(tracepoints.Net(*args))
+
+        # systemd sources
+        args = (self.conf.results_path,)
+        if self.conf.sources.systemd_ipaccounting:
+            sources.append(systemd.IPAccounting(*args))
+
+        return sources
+
     async def run(self):
         """Entry point for the master/control thread."""
 
         while True:
             self.log.info("thread started")
 
-            args = (self.conf.rpc_conf, self.conf.results_path)
-            get_connection_count = rpc.GetConnectionCount(*args)
-            get_peer_info = rpc.GetPeerInfo(*args)
-            get_txoutset_info = rpc.GetTxoutSetInfo(*args)
-            get_node_addresses = rpc.GetNodeAddresses(*args)
-            get_raw_addrman = rpc.GetRawAddrman(*args)
-
-            args = (self.conf.results_path,)
-            ip_accounting = systemd.IPAccounting(*args)
-
-            args = (self.conf.results_path,)
-            net = tracepoints.Net(*args)
-
+            sources = await self.prepare_sources()
             await asyncio.gather(
-                get_connection_count.run(),
-                get_peer_info.run(),
-                get_txoutset_info.run(),
-                get_node_addresses.run(),
-                get_raw_addrman.run(),
-                ip_accounting.run(),
-                net.run(),
+                *[sensor.run() for sensor in sources],
             )
             self.log.info("sleeping for five")
             await asyncio.sleep(5)


### PR DESCRIPTION
My node bandwidth estimates work almost perfectly for inbound traffic. Outbound traffic is way off. My guess is that systemd ip accounting counts RPC traffic. To test this hypothesis, `nix-bitcoin-monitor` needs a switch to turn RPC data sources off. This PR implements that new functionality.

- [x] Add new command line settings
- [x] Integrate new settings into Config
- [x] Activate sensors according to new command line settings
- [x] Test
- [x] Support settings via nix module
- [x] Test
- [x] Merge